### PR TITLE
Update versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["RFC4226", "RFC6238", "OTP", "Authentication"]
 categories = ["authentication"]
 
 [dependencies]
-ring = "0.13.2"
-binascii = "0.1.1"
+ring = "^0.14"
+binascii = "^0.1"
 
 [lib]
 name = "libotp"


### PR DESCRIPTION
Fix error when using the library together with other libraries with the most updated version of the ring crate